### PR TITLE
use LogStash::Util::Charset.new to convert urldecoded string

### DIFF
--- a/lib/logstash/filters/urldecode.rb
+++ b/lib/logstash/filters/urldecode.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require "logstash/util/charset"
 require "uri"
 
 # The urldecode filter is for decoding fields that are urlencoded.
@@ -13,9 +14,18 @@ class LogStash::Filters::Urldecode < LogStash::Filters::Base
   # Urldecode all fields
   config :all_fields, :validate => :boolean, :default => false
 
+  # Thel character encoding used in this filter. Examples include `UTF-8`
+  # and `cp1252`
+  #
+  # This setting is useful if your url decoded string are in `Latin-1` (aka `cp1252`)
+  # or in another character set other than `UTF-8`.
+  config :charset, :validate => ::Encoding.name_list, :default => "UTF-8"
+
   public
   def register
-    # Nothing to do
+    @converter = LogStash::Util::Charset.new(@charset).tap  do |charset|
+      charset.logger = logger
+    end
   end #def register
 
   public
@@ -24,9 +34,7 @@ class LogStash::Filters::Urldecode < LogStash::Filters::Base
 
     # If all_fields is true then try to decode them all
     if @all_fields
-      event.to_hash.each do |name, value|
-        event[name] = urldecode(value)
-      end
+      event.to_hash.each { |name, value| event[name] = urldecode(value) }
     # Else decode the specified field
     else
       event[@field] = urldecode(event[@field])
@@ -40,7 +48,8 @@ class LogStash::Filters::Urldecode < LogStash::Filters::Base
   def urldecode(value)
     case value
     when String
-      return URI.unescape(value)
+      escaped = URI.unescape(value)
+      return @converter.convert(escaped)
     when Array
       ret_values = []
       value.each { |v| ret_values << urldecode(v) }

--- a/lib/logstash/filters/urldecode.rb
+++ b/lib/logstash/filters/urldecode.rb
@@ -23,9 +23,8 @@ class LogStash::Filters::Urldecode < LogStash::Filters::Base
 
   public
   def register
-    @converter = LogStash::Util::Charset.new(@charset).tap  do |charset|
-      charset.logger = logger
-    end
+    @converter = LogStash::Util::Charset.new(@charset)
+    @converter.logger = logger
   end #def register
 
   public

--- a/spec/filters/urldecode_spec.rb
+++ b/spec/filters/urldecode_spec.rb
@@ -4,6 +4,7 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/urldecode"
 
 describe LogStash::Filters::Urldecode do
+  let(:logger) { double(:logger) }
 
   describe "urldecode of correct urlencoded data" do
     # The logstash config goes here.
@@ -48,7 +49,16 @@ describe LogStash::Filters::Urldecode do
       insist { subject["message"] } == "http://logstash.net/docs/1.3.2/filters/urldecode"
       insist { subject["nonencoded"] } == "http://logstash.net/docs/1.3.2/filters/urldecode"
     end
-
   end
 
+   describe "urldecode should replace invalid UTF-8" do
+     config <<-CONFIG
+      filter {
+        urldecode {}
+      }
+     CONFIG
+     sample("message" => "/a/sa/search?rgu=0;+%C3%BB%D3%D0%D5%D2%B5%BD=;+%B7%A2%CB%CD=") do
+      insist { subject["message"] } == "/a/sa/search?rgu=0;+û\\xD3\\xD0\\xD5ҵ\\xBD=;+\\xB7\\xA2\\xCB\\xCD="
+     end
+   end
 end

--- a/spec/filters/urldecode_spec.rb
+++ b/spec/filters/urldecode_spec.rb
@@ -4,8 +4,6 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/urldecode"
 
 describe LogStash::Filters::Urldecode do
-  let(:logger) { double(:logger) }
-
   describe "urldecode of correct urlencoded data" do
     # The logstash config goes here.
     # At this time, only filters are supported.


### PR DESCRIPTION
Fix an issue when url decoded value could have invalid UTF-8 characters.
The unescaped value is converted with `LogStash::Util::Charset` defaulting to UTF-8, invalid character will be escaped.

```
0xD3D0  => \xD3\xD0
```

Fixes https://github.com/elasticsearch/logstash/issues/1695
