### PR TITLE
Add a new setting 'prefix' to decode all parameters starting with it

### DIFF
--- a/lib/logstash/filters/urldecode.rb
+++ b/lib/logstash/filters/urldecode.rb
@@ -14,6 +14,9 @@ class LogStash::Filters::Urldecode < LogStash::Filters::Base
   # Urldecode all fields
   config :all_fields, :validate => :boolean, :default => false
 
+  # Urldecode all fields starting with prefix
+  config :prefix, :validate => :string
+
   # Thel character encoding used in this filter. Examples include `UTF-8`
   # and `cp1252`
   #
@@ -34,6 +37,13 @@ class LogStash::Filters::Urldecode < LogStash::Filters::Base
     # If all_fields is true then try to decode them all
     if @all_fields
       event.to_hash.each { |name, value| event[name] = urldecode(value) }
+    # If a prefix is defined then try to decode all params starting with it
+    elsif !@prefix.nil?
+      event.to_hash.each do |name, value|
+        if name.start_with?(@prefix)
+          event[name] = urldecode(value)
+        end
+      end
     # Else decode the specified field
     else
       event[@field] = urldecode(event[@field])

--- a/lib/logstash/filters/urldecode.rb
+++ b/lib/logstash/filters/urldecode.rb
@@ -17,7 +17,7 @@ class LogStash::Filters::Urldecode < LogStash::Filters::Base
   # Urldecode all fields starting with prefix
   config :prefix, :validate => :string
 
-  # Thel character encoding used in this filter. Examples include `UTF-8`
+  # The character encoding used in this filter. Examples include `UTF-8`
   # and `cp1252`
   #
   # This setting is useful if your url decoded string are in `Latin-1` (aka `cp1252`)

--- a/spec/filters/urldecode_spec.rb
+++ b/spec/filters/urldecode_spec.rb
@@ -59,4 +59,36 @@ describe LogStash::Filters::Urldecode do
       insist { subject["message"] } == "/a/sa/search?rgu=0;+û\\xD3\\xD0\\xD5ҵ\\xBD=;+\\xB7\\xA2\\xCB\\xCD="
      end
    end
+
+   describe "urldecode with a user defined field" do
+    config <<-CONFIG
+      filter {
+        urldecode {
+          field => "foo"
+        }
+      }
+    CONFIG
+
+    sample("message" => "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode", "foo" => "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode") do
+      insist { subject["message"] } == "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode"
+      insist { subject["foo"] } == "http://logstash.net/docs/1.3.2/filters/urldecode"
+    end
+  end
+
+   describe "urldecode with a prefix set to px_" do
+    config <<-CONFIG
+      filter {
+        urldecode {
+          prefix => "px_"
+        }
+      }
+    CONFIG
+
+    sample("message" => "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode", "px_foo" => "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode",
+        "px_bar" => "http%3A%2F%2Flogstash.net") do
+      insist { subject["message"] } == "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode"
+      insist { subject["px_foo"] } == "http://logstash.net/docs/1.3.2/filters/urldecode"
+      insist { subject["px_bar"]} == "http://logstash.net"
+    end
+  end
 end


### PR DESCRIPTION
It can be useful to decode parameters from urls.
Right now, splitting url parameters it's extremely easy using the KV filter, but not decode the parameters values.

Let's put an example using: foo.com/bar?param1=value1&...&paramN=valueN

filters {
  ... # Split url using grok URI pattern or similar

   kv {
     source => "uriparams"
     field_split => "&?"
     prefix => "params_"
   }

   urldecode {
     field_prefix => "params_"
   }
}
With this we can url decode all params using one filter and supporting url params dynamically.

Thanks.

Fixes #2 
