### PR TITLE
Fix dictionary definition passed into the spec methods

### DIFF
--- a/spec/filters/urldecode_spec.rb
+++ b/spec/filters/urldecode_spec.rb
@@ -14,7 +14,7 @@ describe LogStash::Filters::Urldecode do
       }
     CONFIG
 
-    sample("message" => "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode") do
+    sample({"message" => "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode"}) do
       expect(subject.get("message")).to eq "http://logstash.net/docs/1.3.2/filters/urldecode"
       expect(subject.get("tags")).to be_nil
     end
@@ -28,7 +28,7 @@ describe LogStash::Filters::Urldecode do
       }
     CONFIG
 
-    sample("message" => "http://logstash.net/docs/1.3.2/filters/urldecode") do
+    sample({"message" => "http://logstash.net/docs/1.3.2/filters/urldecode"}) do
       expect(subject.get("message")).to eq "http://logstash.net/docs/1.3.2/filters/urldecode"
       expect(subject.get("tags")).to be_nil
     end
@@ -45,7 +45,7 @@ describe LogStash::Filters::Urldecode do
       }
     CONFIG
 
-    sample("message" => "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode", "nonencoded" => "http://logstash.net/docs/1.3.2/filters/urldecode") do
+    sample({"message" => "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode", "nonencoded" => "http://logstash.net/docs/1.3.2/filters/urldecode"}) do
       expect(subject.get("message")).to eq "http://logstash.net/docs/1.3.2/filters/urldecode"
       expect(subject.get("nonencoded")).to eq "http://logstash.net/docs/1.3.2/filters/urldecode"
       expect(subject.get("tags")).to be_nil
@@ -58,7 +58,7 @@ describe LogStash::Filters::Urldecode do
         urldecode {}
       }
      CONFIG
-     sample("message" => "/a/sa/search?rgu=0;+%C3%BB%D3%D0%D5%D2%B5%BD=;+%B7%A2%CB%CD=") do
+     sample({"message" => "/a/sa/search?rgu=0;+%C3%BB%D3%D0%D5%D2%B5%BD=;+%B7%A2%CB%CD="}) do
        expect(subject.get("message")).to eq "/a/sa/search?rgu=0;+û\\xD3\\xD0\\xD5ҵ\\xBD=;+\\xB7\\xA2\\xCB\\xCD="
        expect(subject.get("tags")).to be_nil
      end
@@ -72,7 +72,7 @@ describe LogStash::Filters::Urldecode do
         }
       }
      CONFIG
-     sample("url" => "/fr/search-results?queryText=Organigramme%20de%20la%20Commission%20europ%C3%A9enne%201998&additionalTextParam=organigramme%20de%20la%20commission%20européenne%201998") do
+     sample({"url" => "/fr/search-results?queryText=Organigramme%20de%20la%20Commission%20europ%C3%A9enne%201998&additionalTextParam=organigramme%20de%20la%20commission%20européenne%201998"}) do
        expect(subject.get("url")).to eq "/fr/search-results?queryText=Organigramme de la Commission européenne 1998&additionalTextParam=organigramme de la commission européenne 1998"
        expect(subject.get("tags")).to be_nil
      end
@@ -86,7 +86,7 @@ describe LogStash::Filters::Urldecode do
         }
       }
      CONFIG
-     sample("url" => "http%3A%2F%2Fl%C3%B8gstash.net%2Fd%C3%B8cs%2F1.3.2%2Ffilters%2Furldecøde?name=frødø%20båggins") do
+     sample({"url" => "http%3A%2F%2Fl%C3%B8gstash.net%2Fd%C3%B8cs%2F1.3.2%2Ffilters%2Furldecøde?name=frødø%20båggins"}) do
        expect(subject.get("url")).to eq "http://løgstash.net/døcs/1.3.2/filters/urldecøde?name=frødø båggins"
        expect(subject.get("tags")).to be_nil
      end
@@ -98,7 +98,7 @@ describe LogStash::Filters::Urldecode do
         urldecode {}
       }
      CONFIG
-     sample("message" => {"url" => "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode"}) do
+     sample({"message" => {"url" => "http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode"}}) do
        expect(subject.get("[message][url]")).to eq "http://logstash.net/docs/1.3.2/filters/urldecode"
        expect(subject.get("tags")).to be_nil
      end
@@ -110,7 +110,7 @@ describe LogStash::Filters::Urldecode do
         urldecode {}
       }
      CONFIG
-     sample("message" => ["http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode"]) do
+     sample({"message" => ["http%3A%2F%2Flogstash.net%2Fdocs%2F1.3.2%2Ffilters%2Furldecode"]}) do
        expect(subject.get("[message][0]")).to eq "http://logstash.net/docs/1.3.2/filters/urldecode"
        expect(subject.get("tags")).to be_nil
      end


### PR DESCRIPTION
Fix dictionary definition passed into the spec methods, to be compliant with JRuby 9.4

## How to test
Same steps as https://github.com/logstash-plugins/logstash-filter-cidr/pull/26
